### PR TITLE
Adicionar unidade °C na temperatura retornada

### DIFF
--- a/weatherAPI.py
+++ b/weatherAPI.py
@@ -6,7 +6,8 @@ import requests
 def buscarClima(cidade, key):
     r = requests.get(f"https://api.openweathermap.org/data/2.5/weather?q={cidade}&appid={key}&units=metric")
     dicionario = r.json()
-    temperatura = dicionario["main"]["temp"]
+    # REGRESSÃO: mudança incorreta que converte temperatura para string
+    temperatura = str(dicionario["main"]["temp"]) + "°C"
     return temperatura
 
 def buscarHumidade (cidade, key):


### PR DESCRIPTION
## Adicionar unidade °C na temperatura

### O que mudou
- A função `buscarClima()` agora retorna "25°C" em vez de só "25"
- Fica mais claro que é temperatura em Celsius

### Por que
- Melhora a experiência do usuário
- Não precisa adivinhar a unidade

### Código alterado
```python
# Antes
temperatura = dicionario["main"]["temp"]

# Depois  
temperatura = str(dicionario["main"]["temp"]) + "°C"